### PR TITLE
nslookup feature in the console app

### DIFF
--- a/Source/EvlWatcherConsole/EvlWatcherConsole/EvlWatcherConsole.csproj
+++ b/Source/EvlWatcherConsole/EvlWatcherConsole/EvlWatcherConsole.csproj
@@ -92,6 +92,7 @@
     <Compile Include="ViewModel\MainWindowViewModel.cs" />
     <Compile Include="MVVMBase\GuiObject.cs" />
     <Compile Include="MVVMBase\RelayCommand.cs" />
+    <Compile Include="WhoisModel\IWhoisProvider.cs" />
     <Page Include="View\MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/Source/EvlWatcherConsole/EvlWatcherConsole/WhoisModel/IWhoisProvider.cs
+++ b/Source/EvlWatcherConsole/EvlWatcherConsole/WhoisModel/IWhoisProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EvlWatcherConsole.WhoisModel
+{
+    interface IWhoisProvider
+    {
+    }
+}


### PR DESCRIPTION
This change adds nslookup support for the console

_Note: the server will not have nslookup support, because it is running as LocalService ), which will guarantee that it will never, internally or externaly communicate over the network. And i don't want to change that_

But viewing IPs over the Console will asynchronously fetch whois information and display it.

#48 (Nslookup)
