### PR TITLE
Add configuration for the Windows OpenSSH service.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,11 @@
 If there is anything you can contribute, PLEASE do so, for whatever reason (specific issue, code smells, whatever). 
 Just make a pull request, and request it to be merged. If there are any issues you resolve with the pull request, make sure to link to them.
 
-Every once in a while, all the merged stuff will be put to the test and finally become a new version. 
+## Making a pull request.
+There is always branch for version that is currently up next (for example "v2.1.3" ). When you make a pull request, please let it base on that branch, never on master.
+Thats all.
+
+Every once in a while, all the things in the new version branch will be put to the test and finally become a new release.
 (depending on what has changed, that can be more or less frequent. Weeks, YEARS, DECADES, MILLENIA, or never)
 
 ## Before you start coding, please keep the following things in mind:

--- a/Source/EvlWatcher/EvlWatcher/config.xml
+++ b/Source/EvlWatcher/EvlWatcher/config.xml
@@ -167,5 +167,44 @@
         </Regex>
 
     </Task>
+    <Task Name="BlockSSHBrutersByOpenSsh" Active="true">
+      <!-- the description ..-->
+      <Description>
+          This rule checks for failed SSH logins.
+      </Description>
+      <!-- this is the time a temporary ban is issued for, in seconds-->
+      <LockTime>
+          3600
+        </LockTime>
+      <!-- this is used for rules that only need new events for evaluating. If you dont know what this does, leave it set to false-->
+      <OnlyNew>
+          False
+      </OnlyNew>
+      <!-- this is the timeframe (in seconds) to be inspected-->
+      <EventAge>
+          120
+      </EventAge>
+      <!-- this is the amount of times an entry must occure within the time frame to be considered a brute force attempt-->
+      <TriggerCount>
+          5
+      </TriggerCount>
+      <!-- after this amount of times temporarily banned, the ban will become permanent -->
+      <PermaBanCount>
+          3
+      </PermaBanCount>
+      <!-- This is the place where the rule looks for entries-->
+      <EventPath>
+          OpenSSH/Operational
+      </EventPath>
+      <!-- This was introduced because sole regex matching is too CPU intensive. it incredibly speeds up the filtering when you enter some (or at least one) words that MUST be contained in the LogEntry to undergo the regex inspection-->
+      <RegexBoosters>
+        <Booster>Failed password</Booster>
+      </RegexBoosters>
+      <!-- This is the regex that tries to extract an IP from the entries that contain the booster words for more infos see regex101.com-->
+      <Regex>
+          (\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b)
+      </Regex>
+    </Task>
+    
   </Tasks>
 </Config>


### PR DESCRIPTION
I added a rule to the config for OpenSSH support for Windows.

* It uses the OpenSSH/Operational log
* As multiple logs entries are created for each failed login, I use the "Failed password..." entry. This ensures that incorrect passwords with correct users (which are not logged as a separate event) will be banned
* I use a generic IPv4 regex to match the IP address - this can be changed if you want, but there is other text in the XML node  that made writing a more complex rule more difficult:
  ```<Data Name="payload">Failed password for invalid user user from xxx.xxx.xxx.xxx port xxxx ssh2</Data>```
  
I've tested this rule with my Microsoft Windows 10 Professional install with OpenSSH installed and enabled. Additional testers would be welcome to review.